### PR TITLE
No longer bundle all code in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ each country. Please choose a snipped based on the ngo and country that fits you
 
 ```html
 
-<script type="module" crossorigin src="https://turbine-kreuzberg.github.io/vida/code.js"></script>
-<link rel="stylesheet" href="https://turbine-kreuzberg.github.io/vida/style.css">
+<script type="module" crossorigin src="https://turbine-kreuzberg.github.io/vida/index.js"></script>
+<link rel="stylesheet" href="https://turbine-kreuzberg.github.io/vida/index.css">
 <script type="text/javascript">
   window.addEventListener('vida-loaded', function (e) {
     window.vida = e.detail
@@ -41,8 +41,8 @@ each country. Please choose a snipped based on the ngo and country that fits you
 
 ```html
 
-<script type="module" crossorigin src="https://turbine-kreuzberg.github.io/vida/code.js"></script>
-<link rel="stylesheet" href="https://turbine-kreuzberg.github.io/vida/style.css">
+<script type="module" crossorigin src="https://turbine-kreuzberg.github.io/vida/index.js"></script>
+<link rel="stylesheet" href="https://turbine-kreuzberg.github.io/vida/index.css">
 <script type="text/javascript">
   window.addEventListener('vida-loaded', function (e) {
     window.vida = e.detail

--- a/TODOS.md
+++ b/TODOS.md
@@ -3,5 +3,5 @@
 - [ ] Have content page images with relative paths
 - [ ] Introduce markers and headline for safe-places map
 - [ ] Verify if open-street-map is using cookies
-- [ ] There should only be 2 files in dist folder (code.js and style.css)
+- [x] There should only be 2 files in dist folder (code.js and style.css) / After investigation not needed 
 - [ ] Internationalization

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,11 +25,10 @@ export default defineConfig({
     })
   ],
   build: {
-    cssCodeSplit: false,
     rollupOptions: {
       output: {
         assetFileNames: '[name].[ext]',
-        entryFileNames: 'code.js'
+        entryFileNames: 'index.js'
       }
     }
   }


### PR DESCRIPTION
It turned out that vite resolves the chunks of code very well (relative to index.js). Due to this it is not necessary to pack everything into one-file.

- updated docs
- updated example snippets